### PR TITLE
fix: prevent limit property overriding

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -32,10 +32,10 @@ const getAllBlocks = async ({
       cookie: `token_v2=${token};`
     },
     body: JSON.stringify({
-      limit,
       cursor: { stack },
       chunkNumber,
       ...body,
+      limit,
       verticalColumns: false
     }),
     method: "POST"


### PR DESCRIPTION
Destruction of the body always overrides value of the limit property. Since limit is the required property for notion API we always receive ValidationError.

There is no contribution guide in the repository :( but i fixed a little bug with the limit property described here #16 